### PR TITLE
MNT: Drop Python 3.7 support, test on 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9']
         shell: ['bash']
         include:
           - os: 'windows-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,6 @@ include = ["tox.ini", "tests/*.py"]
 [tool.setuptools_scm]
 write_to = "src/nipreps_versions/_version.py"
 
-[tool.black]
-extend-exclude = "_version.py"
-
-[tool.isort]
-profile = "black"
-
 [tool.mypy]
 python_version = "3.8"
 
@@ -63,3 +57,48 @@ omit = ["_version.py"]
 
 [tool.coverage.report]
 fail_under = 100
+
+[tool.ruff.lint]
+extend-select = [
+  "W",
+  "C90",
+  "I",
+  "N",
+  # "D",  # pydocstyle
+  "UP",
+  "YTT",
+  # "ANN",  # annotations
+  # "S",  # bandit
+  "BLE",
+  "FBT",
+  "B",
+  "A",
+  "C4",
+  "DTZ",
+  "T10",
+  "EM",
+  "EXE",
+  "ISC",
+  "ICN",
+  "PIE",
+  "T20",
+  "PYI",
+  # "PT",  # pytest-style
+  "Q",
+  "RSE",
+  "RET",
+  "SLF",
+  "SLOT",
+  # "SIM",  # simplify
+  "TID",
+  "TCH",
+  "ARG",
+  "ERA",
+  "PL",
+  "FLY",
+  "PERF",
+  "RUF",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["nipreps_versions"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ extend-select = [
   "PIE",
   "T20",
   "PYI",
-  # "PT",  # pytest-style
+  "PT",  # pytest-style
   "Q",
   "RSE",
   "RET",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ omit = ["_version.py"]
 [tool.coverage.report]
 fail_under = 100
 
+[tool.ruff]
+extend-exclude = ["_version.py"]
+
 [tool.ruff.lint]
 extend-select = [
   "W",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ extend-select = [
   # "D",  # pydocstyle
   "UP",
   "YTT",
-  # "ANN",  # annotations
+  "ANN",  # annotations
   # "S",  # bandit
   "BLE",
   "FBT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Version Control",
   "Topic :: System :: Software Distribution",
@@ -30,7 +30,7 @@ dependencies = [
   "setuptools_scm >=7",
   "packaging",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Home = "https://github.com/nipreps/version-schemes"
@@ -52,7 +52,7 @@ extend-exclude = "_version.py"
 profile = "black"
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 
 [[tool.mypy.overrides]]
 module = ["setuptools_scm.version", "setuptools_scm.config"]

--- a/src/nipreps_versions/__init__.py
+++ b/src/nipreps_versions/__init__.py
@@ -1,4 +1,4 @@
 try:
-    from ._version import __version__
+    from ._version import __version__  # noqa: F401
 except ImportError:  # pragma: no cover
     pass

--- a/src/nipreps_versions/schemes.py
+++ b/src/nipreps_versions/schemes.py
@@ -1,7 +1,5 @@
-import re
-import warnings
 from datetime import date, datetime, timezone
-from typing import Match, Optional
+from typing import Optional
 
 import packaging.version
 from setuptools_scm.version import (

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -11,7 +11,7 @@ m = partial(meta, config=Configuration())
 
 
 @pytest.mark.parametrize(
-    "version, expected_next",
+    ("version", "expected_next"),
     [
         pytest.param(m("22.1.0"), "22.1.0", id="exact"),
         pytest.param(

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import pytest
 from setuptools_scm import Configuration  # type: ignore
-from setuptools_scm.version import meta  # type: ignore
+from setuptools_scm.version import ScmVersion, meta
 
 from nipreps_versions.schemes import next_calver, nipreps_calver
 
@@ -76,11 +76,11 @@ m = partial(meta, config=Configuration())
         ),
     ],
 )
-def test_nipreps_calver(version, expected_next):
+def test_nipreps_calver(version: ScmVersion, expected_next: str) -> None:
     assert nipreps_calver(version) == expected_next
 
 
-def test_next_calver():
+def test_next_calver() -> None:
     # Omit optional arguments always passed by nipreps_calver
     assert (
         next_calver(

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,12 @@ python =
 deps =
     pytest
     pytest-cov
-    black
-    isort[colors]
+    ruff
     tomli; python_version < "3.11"
     !pypy3: mypy
 
 commands =
-    black --check --diff --color .
-    isort --check --diff --color .
+    ruff .
+    ruff format --diff .
     pytest -sv tests/ --cov=nipreps_versions
     !pypy3: mypy src tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = py{37,38,39,310,311,py3}
+envlist = py{38,39,310,311,312,py3}
 skip_missing_interpreters = True
 isolated_build = true
 
 [gh-actions]
 python =
-  3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
   pypy-3.9: pypy3
 
 [testenv]


### PR DESCRIPTION
Some style cleanups while we're at it.